### PR TITLE
React SoundCloud Player

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require payola
 //= require bootstrap-sprockets
 //= require jquery_ujs
+//= require soundcloud-audio
 //= require react
 //= require react_ujs
 //= require components

--- a/app/assets/javascripts/components/player.js.jsx
+++ b/app/assets/javascripts/components/player.js.jsx
@@ -1,0 +1,67 @@
+var Player = React.createClass({
+
+  getInitialState: function() {
+    return {
+      player: this.props.player,
+      currentTime: 0,
+      isPlaying: false
+    }
+  },
+
+  componentDidMount: function() {
+    var component = this;
+    console.log(this.state.player);
+
+    // Listen for the timeupdate event, so when the
+    // song is playing the elapsed-time Timer gets
+    // updated.
+    this.state.player.on('timeupdate', function(audio) {
+      component.setState({currentTime: audio.target.currentTime});
+    });
+
+  },
+
+  componentWillReceiveProps: function(newProps) {
+    if (this.state.isPlaying) {
+      this.state.player.stop();
+      this.state.player.play();
+    }
+  },
+
+  componentWillUnmount: function() {
+    this.state.player.unbindAll();
+  },
+
+  playTrack: function(e) {
+    e.preventDefault();
+    var component = this;
+
+    if (this.state.isPlaying === true) {
+      this.state.player.pause();
+      this.setState({isPlaying: false});
+    } else {
+      this.state.player.play();
+      this.setState({isPlaying: true});
+    }
+  },
+
+  handleProgressClick: function(e) {
+    console.log(e);
+  },
+
+  render: function() {
+    var playerControl = this.state.isPlaying ? "fa fa-pause" : "fa fa-play";
+    return(
+      <div className="soundcloud-player">
+        <i className={playerControl} onClick={this.playTrack}></i>
+        <p className="track-title">{this.props.currentTrack.title}</p>
+        <div className="progress-bar">
+          <Timer timeValue={this.state.currentTime} className="elapsed-time" />
+          <progress max={this.state.player.duration} value={this.state.currentTime}>
+          </progress>
+          <Timer timeValue={this.state.player.duration} className="total-time"/>
+        </div>
+      </div>
+    );
+  }
+});

--- a/app/assets/javascripts/components/sound_cloud_container.js.jsx
+++ b/app/assets/javascripts/components/sound_cloud_container.js.jsx
@@ -1,0 +1,37 @@
+var SoundCloudContainer = React.createClass({
+
+  getInitialState: function() {
+    return {
+      player: new SoundCloudAudio('67f5f6bd5ecee04b89566b5fccacc136'),
+      currentTrack: {}
+    }
+  },
+
+  componentDidMount: function() {
+    this.resolveTrack(this.props.trackUrl);
+    ee.addListener('track-selected', this.handleSelectedTrack);
+  },
+
+  handleSelectedTrack: function(track) {
+    console.log(track);
+    this.resolveTrack(track);
+  },
+
+  resolveTrack: function(trackUrl) {
+    var component = this;
+
+    scPlayer = this.state.player;
+    scPlayer.resolve(trackUrl, function(track, err) {
+      component.setState({currentTrack: track});
+    });
+  },
+
+  render: function() {
+    var component = this;
+    return(
+      <footer className="footer bg-dark player">
+        <Player player={this.state.player} currentTrack={component.state.currentTrack} />
+      </footer>
+    );
+  }
+});

--- a/app/assets/javascripts/components/timer.js.jsx
+++ b/app/assets/javascripts/components/timer.js.jsx
@@ -1,0 +1,37 @@
+var Timer = React.createClass({
+
+  getInitialState: function() {
+    return { timeValue: this.props.timeValue }
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({timeValue: nextProps.timeValue});
+  },
+
+  prettyTime: function(time) {
+    var hours = Math.floor(time / 3600);
+    var mins = '0' + Math.floor((time % 3600) / 60);
+    var secs = '0' + Math.floor((time % 60));
+
+    mins = mins.substr(mins.length - 2);
+    secs = secs.substr(secs.length - 2);
+
+    if (!isNaN(secs)) {
+      if (hours) {
+        return hours + ":" + mins + ":" + secs;
+      } else {
+        return mins + ":" + secs;
+      }
+      } else {
+        return '00:00';
+      }
+   },
+
+  render: function() {
+    return (
+      <div>
+        <span className={this.props.className}>{this.prettyTime(this.state.timeValue)}</span>
+      </div>
+    );
+  }
+});

--- a/app/assets/stylesheets/_player.scss
+++ b/app/assets/stylesheets/_player.scss
@@ -1,0 +1,62 @@
+.player {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+
+  .soundcloud-player {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    width: 100%;
+
+    i {
+      font-size: 2em;
+      margin-right: 30px;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    .track-title {
+      width: 20%;
+      margin-right: 30px;
+    }
+
+    p {
+      margin: 0;
+      padding: 0;
+    }
+
+    .progress-bar {
+      display: flex;
+      align-items: center;
+      width: 80%;
+      background-color: #5A6A7A;
+
+      span {
+        font-size: 12px;
+      }
+
+      .elapsed-time {
+        margin-right: 15px;
+      }
+
+      .total-time {
+        margin-left: 15px;
+      }
+
+      progress {
+        width: 600px;
+        height: 12px;
+        appearance: none;
+        border-radius: 2px;
+        border: 0;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,5 @@
 @import 'font-awesome.min.scss';
 @import 'font.scss';
 @import 'simple-line-icons.scss';
+
+@import 'player';

--- a/app/views/layouts/_react_player.html.erb
+++ b/app/views/layouts/_react_player.html.erb
@@ -1,0 +1,2 @@
+<%= react_component 'SoundCloudContainer',
+    { trackUrl: 'https://soundcloud.com/daze-of-resistance/the-ocean-is-in-the-clouds'} %>

--- a/app/views/musik/index.html.erb
+++ b/app/views/musik/index.html.erb
@@ -15,7 +15,7 @@
                   <%= render 'layouts/top_songs' %>
                 </div>
               </section>
-              <%= render 'layouts/player' %>
+              <%= render 'layouts/react_player' %>
             </section>
           </section>
           <!-- side content -->

--- a/vendor/assets/javascripts/soundcloud-audio.js
+++ b/vendor/assets/javascripts/soundcloud-audio.js
@@ -1,0 +1,168 @@
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var o;"undefined"!=typeof window?o=window:"undefined"!=typeof global?o=global:"undefined"!=typeof self&&(o=self),o.SoundCloudAudio=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"/Users/dmitri/github/soundcloud-html5-audio":[function(require,module,exports){
+'use strict';
+
+function SoundCloud (clientId) {
+    if (!(this instanceof SoundCloud)) {
+        return new SoundCloud(clientId);
+    }
+
+    if (!clientId) {
+        throw new Error('SoundCloud API clientId is required, get it - https://developers.soundcloud.com/');
+    }
+
+    this._events = {};
+
+    this._clientId = clientId;
+    this._baseUrl = 'https://api.soundcloud.com';
+
+    this.playing = false;
+    this.duration = 0;
+
+    this.audio = document.createElement('audio');
+}
+
+SoundCloud.prototype.resolve = function (url, callback) {
+    if (!url) {
+        throw new Error('SoundCloud track or playlist url is required');
+    }
+
+    url = this._baseUrl + '/resolve.json?url=' + url + '&client_id=' + this._clientId;
+
+    this._jsonp(url, function (data) {
+        if (Array.isArray(data)) {
+            var tracks = data;
+            data = {tracks: tracks};
+            this._playlist = data;
+        } else if (data.tracks) {
+            this._playlist = data;
+        } else {
+            this._track = data;
+        }
+
+        this.duration = data.duration && !isNaN(data.duration) ?
+            data.duration / 1000 : // convert to seconds
+            0; // no duration is zero
+
+        callback(data);
+    }.bind(this));
+};
+
+SoundCloud.prototype._jsonp = function (url, callback) {
+    var target = document.getElementsByTagName('script')[0] || document.head;
+    var script = document.createElement('script');
+
+    var id = 'jsonp_callback_' + Math.round(100000 * Math.random());
+    window[id] = function (data) {
+        if (script.parentNode) {
+            script.parentNode.removeChild(script);
+        }
+        window[id] = function () {};
+        callback(data);
+    };
+
+    script.src = url + (url.indexOf('?') >= 0 ? '&' : '?') + 'callback=' + id;
+    target.parentNode.insertBefore(script, target);
+};
+
+SoundCloud.prototype.on = function (e, fn) {
+    this._events[e] = fn;
+    this.audio.addEventListener(e, fn, false);
+};
+
+SoundCloud.prototype.off = function (e, fn) {
+    this._events[e] = null;
+    this.audio.removeEventListener(e, fn);
+};
+
+SoundCloud.prototype.unbindAll = function () {
+    for (var e in this._events) {
+        var fn = this._events[e];
+        if (fn) {
+            this.off(e, fn);
+        }
+    }
+};
+
+SoundCloud.prototype.preload = function (streamUrl) {
+    this._track = {stream_url: streamUrl};
+    this.audio.src = streamUrl + '?client_id=' + this._clientId;
+};
+
+SoundCloud.prototype.play = function (options) {
+    options = options || {};
+    var src;
+
+    if (options.streamUrl) {
+        src = options.streamUrl;
+    } else if (this._playlist) {
+        var length = this._playlist.tracks.length;
+        if (length) {
+            this._playlistIndex = options.playlistIndex || 0;
+
+            // be silent if index is out of range
+            if (this._playlistIndex >= length || this._playlistIndex < 0) {
+                this._playlistIndex = 0;
+                return;
+            }
+            src = this._playlist.tracks[this._playlistIndex].stream_url;
+        }
+    } else if (this._track) {
+        src = this._track.stream_url;
+    }
+
+    if (!src) {
+        throw new Error('There is no tracks to play, use `streamUrl` option or `load` method');
+    }
+
+    src += '?client_id=' + this._clientId;
+
+    if (src !== this.audio.src) {
+        this.audio.src = src;
+    }
+
+    this.playing = src;
+    this.audio.play();
+};
+
+SoundCloud.prototype.pause = function () {
+    this.audio.pause();
+    this.playing = false;
+};
+
+SoundCloud.prototype.stop = function () {
+    this.audio.pause();
+    this.audio.currentTime = 0;
+    this.playing = false;
+};
+
+SoundCloud.prototype.next = function () {
+    var tracksLength = this._playlist.tracks.length;
+    if (this._playlistIndex >= tracksLength - 1) {
+        return;
+    }
+    if (this._playlist && tracksLength) {
+        this.play({playlistIndex: ++this._playlistIndex});
+    }
+};
+
+SoundCloud.prototype.previous = function () {
+    if (this._playlistIndex <= 0) {
+        return;
+    }
+    if (this._playlist && this._playlist.tracks.length) {
+        this.play({playlistIndex: --this._playlistIndex});
+    }
+};
+
+SoundCloud.prototype.seek = function (e) {
+    if (!this.audio.readyState) {
+        return false;
+    }
+    var percent = e.offsetX / e.target.offsetWidth || (e.layerX - e.target.offsetLeft) / e.target.offsetWidth;
+    this.audio.currentTime = percent * (this.audio.duration || 0);
+};
+
+module.exports = SoundCloud;
+
+},{}]},{},["/Users/dmitri/github/soundcloud-html5-audio"])("/Users/dmitri/github/soundcloud-html5-audio")
+});


### PR DESCRIPTION
Added the `soundcloud-audio` JS library and the React components to play tunes from SoundCloud. 

The basic styling for the player is located in the `_player.scss` partial in the stylesheets directory. The only style that is being used within the player from the original theme pack are the `footer bg-dark` classes. 

Scrubbing is still not implemented. 

![Code On Young Man](https://media.giphy.com/media/cg5FwpvDmhIcM/giphy.gif)
