### PR TITLE
Add top 100 to daily update email

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,10 +1,17 @@
 class AdminMailer < ApplicationMailer
-default from: "#{ENV["GMAIL_USERNAME_DEV"]}@gmail.com"
+  default from: "#{ENV["GMAIL_USERNAME_DEV"]}@gmail.com"
 
   def daily_update_email
+    client = SoundCloudAPI.new
+    @top_hunnad = client.hot_tracks(100)
 
-  mail(to: ENV["ADMIN_RECIPIENT_EMAIL"], subject: 'Musik Daily Stats')
+    mail(to: ENV["ADMIN_RECIPIENT_EMAIL"], subject: 'Musik Daily Stats')
+  end
 
+  def top_hundred
+    @hello = "Hello"
+    @client = SoundCloudAPI.new
+    @top_hunnad = @client.hot_tracks(100)
   end
 
 end

--- a/app/views/admin_mailer/daily_update_email.html.erb
+++ b/app/views/admin_mailer/daily_update_email.html.erb
@@ -4,6 +4,9 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
 </head>
   <body>
-<p>This is a test email :)</p>
+<h1>Today's Top 100 Tracks:</h1>
+  <% @top_hunnad.each do |track| %>
+    <p><%= track.title %></p>
+  <% end %>
   </body>
 </html>


### PR DESCRIPTION
This adds a list of the top 100 songs to the daily update email, which can be sent using the Heroku Scheduler.
